### PR TITLE
Anchor pages in a static viewport

### DIFF
--- a/community/index.html
+++ b/community/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Jannick Stein</title>
+    <title>Community — Jannick Stein</title>
     <style>
         :root {
             --bg: #ffffff;
@@ -126,19 +126,16 @@
     <div class="layout">
         <nav>
             <ul class="nav-links">
-                <li><span class="active">About</span></li>
-                <li><a href="/community/">Community</a></li>
+                <li><a href="/">About</a></li>
+                <li><span class="active">Community</span></li>
                 <li><a href="/investing/">Investing</a></li>
             </ul>
         </nav>
         <main>
             <section>
-                <p>Hi, I’m Jannick.</p>
-                <p>I invest in exceptional people to build startups from scratch at <a href="https://www.joinef.com" target="_blank" rel="noreferrer">Entrepreneurs First</a>. I also run <a href="/community/">Chiefs Of Stuff</a>, a community of hundreds of generalist operators.</p>
-                <p>I believe generalists run the world. They embody ambition, curiosity, and, most importantly, versatility. To learn more about generalism, read my blog post: <a href="https://www.generalism.blog/p/the-generalist-edge" target="_blank" rel="noreferrer">The Generalist Edge</a>.</p>
-                <p>Previously, I’ve spent four years working as a Chief of Staff and startup generalist at <a href="https://ledgy.com/" target="_blank" rel="noreferrer">Ledgy</a> and <a href="https://www.producthunt.com/products/acapela" target="_blank" rel="noreferrer">Acapela</a>. I also learned a lot working in VC at <a href="https://www.globalfounderscapital.com/" target="_blank" rel="noreferrer">Global Founders Capital</a>, <a href="https://earlybird.com/" target="_blank" rel="noreferrer">Earlybird</a>, and <a href="https://www.b2venture.vc/" target="_blank" rel="noreferrer">b2venture</a>. I graduated from the University of St. Gallen with a BA in Business Administration.</p>
-                <p>I grew up in Northern Germany and currently live in London. I love coffee, chess, and drumming.</p>
-                <p>I like to meet new people, especially if they’re opinionated. Reach out to me via <a href="https://twitter.com/jannickstein" target="_blank" rel="noreferrer">Twitter</a> and <a href="https://www.linkedin.com/in/jannickstein/" target="_blank" rel="noreferrer">LinkedIn</a> DMs.</p>
+                <p>Community is where I host Chiefs Of Stuff—a private network for generalist operators and Chiefs of Staff.</p>
+                <p>We gather to swap playbooks, surface opportunities, and share the unpolished lessons from building alongside ambitious founders.</p>
+                <p>If that sounds like you, learn more at <a href="https://chiefsofstuff.com/" target="_blank" rel="noreferrer">chiefsofstuff.com</a>.</p>
             </section>
         </main>
     </div>

--- a/investing/index.html
+++ b/investing/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Jannick Stein</title>
+    <title>Investing — Jannick Stein</title>
     <style>
         :root {
             --bg: #ffffff;
@@ -126,19 +126,16 @@
     <div class="layout">
         <nav>
             <ul class="nav-links">
-                <li><span class="active">About</span></li>
+                <li><a href="/">About</a></li>
                 <li><a href="/community/">Community</a></li>
-                <li><a href="/investing/">Investing</a></li>
+                <li><span class="active">Investing</span></li>
             </ul>
         </nav>
         <main>
             <section>
-                <p>Hi, I’m Jannick.</p>
-                <p>I invest in exceptional people to build startups from scratch at <a href="https://www.joinef.com" target="_blank" rel="noreferrer">Entrepreneurs First</a>. I also run <a href="/community/">Chiefs Of Stuff</a>, a community of hundreds of generalist operators.</p>
-                <p>I believe generalists run the world. They embody ambition, curiosity, and, most importantly, versatility. To learn more about generalism, read my blog post: <a href="https://www.generalism.blog/p/the-generalist-edge" target="_blank" rel="noreferrer">The Generalist Edge</a>.</p>
-                <p>Previously, I’ve spent four years working as a Chief of Staff and startup generalist at <a href="https://ledgy.com/" target="_blank" rel="noreferrer">Ledgy</a> and <a href="https://www.producthunt.com/products/acapela" target="_blank" rel="noreferrer">Acapela</a>. I also learned a lot working in VC at <a href="https://www.globalfounderscapital.com/" target="_blank" rel="noreferrer">Global Founders Capital</a>, <a href="https://earlybird.com/" target="_blank" rel="noreferrer">Earlybird</a>, and <a href="https://www.b2venture.vc/" target="_blank" rel="noreferrer">b2venture</a>. I graduated from the University of St. Gallen with a BA in Business Administration.</p>
-                <p>I grew up in Northern Germany and currently live in London. I love coffee, chess, and drumming.</p>
-                <p>I like to meet new people, especially if they’re opinionated. Reach out to me via <a href="https://twitter.com/jannickstein" target="_blank" rel="noreferrer">Twitter</a> and <a href="https://www.linkedin.com/in/jannickstein/" target="_blank" rel="noreferrer">LinkedIn</a> DMs.</p>
+                <p>I mostly invest through my investing role at Entrepreneurs First and very selectively invest in pre-seed and seed stage companies.</p>
+                <p>I love to help founders through the earliest phases of their journey and am usually most helpful thinking through ideation, early hires, and team-building.</p>
+                <p>If you’d like to collaborate, <a href="mailto:jannick@joinef.com">email me</a> or reach out on <a href="https://twitter.com/jannickstein" target="_blank" rel="noreferrer">Twitter</a>.</p>
             </section>
         </main>
     </div>


### PR DESCRIPTION
## Summary
- pin each page to a minimalist, non-scrolling viewport frame with condensed typography and tighter spacing
- align the left navigation and content closer to the edge for a saradu.com-inspired composition
- rename the Chiefs Of Stuff route to /community and update internal references accordingly

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68dfcfe61798832e967c31f88f17d215