### PR TITLE
Adjust mobile spacing for home layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -104,6 +104,11 @@ a:focus {
         font-size: 15px;
     }
 
+    .wrapper {
+        gap: 1rem;
+        padding: clamp(1.25rem, 6vw, 2rem) clamp(1.25rem, 6vw, 2rem) clamp(3.5rem, 12vw, 5rem);
+    }
+
     main {
         max-width: none;
     }


### PR DESCRIPTION
## Summary
- reduce the vertical gap between the navigation and content on small screens so the layout feels tighter on mobile
- add extra bottom padding on mobile to keep the page feeling balanced without introducing extra scroll

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68dfee5b2764832ebdae181cf72db2bf