### PR TITLE
Further tighten mobile navigation spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -105,11 +105,28 @@ a:focus {
     }
 
     .wrapper {
-        gap: 1rem;
-        padding: clamp(1.25rem, 6vw, 2rem) clamp(1.25rem, 6vw, 2rem) clamp(3.5rem, 12vw, 5rem);
+        gap: clamp(0.35rem, 3vw, 0.75rem);
+        padding: clamp(0.75rem, 4vw, 1.25rem) clamp(1.25rem, 6vw, 2rem) clamp(2.5rem, 9vw, 3.5rem);
+    }
+
+    nav {
+        display: flex;
+        justify-content: center;
+        padding-top: 0.4rem;
     }
 
     main {
         max-width: none;
+    }
+
+    .nav-links {
+        flex-direction: row;
+        justify-content: center;
+        gap: clamp(0.75rem, 5vw, 1.5rem);
+    }
+
+    .nav-links li {
+        display: flex;
+        align-items: center;
     }
 }


### PR DESCRIPTION
## Summary
- further reduce the small-screen wrapper gap and padding so the navigation sits closer to the content
- keep a touch of top padding on the mobile navigation bar while maintaining a compact header

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e00b52be44832e8f24d8b0beb966a9